### PR TITLE
Automatically resolve MFA ARN when assuming roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ at the root of the project.
 
 Assume role with elevated permissions:
 ```
-eval $(aws-cli-assumerole -rmfa <role-arn> <your-username> <mfa-otp-code>)
+eval $(aws-cli-assumerole -rmfa <role-arn> <mfa-otp-code>)
 ```
 
 Work with terraform as usual:


### PR DESCRIPTION
If we make the assumption that the currently active credentials (e.g in `~/.aws`) are for a MFA enabled User, we can use the caller identity to infer both their username and the ARN of the MFA device associated with them.

The target AWS account is solely specified by the ROLE_ARN parameter.